### PR TITLE
Basic modifications of window ntuple script for use with hgcalsim production tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ working title: Castrop-Rauxel
 
 ```shell
 # variables
-export SCRAM_ARCH="slc7_amd64_gcc700"
-export CMSSW_VERSION="CMSSW_11_0_0_pre3"
+export SCRAM_ARCH="slc7_amd64_gcc820"
+export CMSSW_VERSION="CMSSW_11_0_0_pre9"
 
 # setup CMSSW
 source "/cvmfs/cms.cern.ch/cmsset_default.sh" ""
@@ -16,7 +16,7 @@ cd "$CMSSW_VERSION/src"
 cmsenv
 
 # setup the graphreco repo
-git clone git@github.com:riga/graphreco.git RecoHGCal/GraphReco
+git clone https://github.com/jkiesele/graphreco.git RecoHGCal/GraphReco
 
 # compile
 scram b -j

--- a/test/windowNTuple_cfg.py
+++ b/test/windowNTuple_cfg.py
@@ -12,25 +12,26 @@ import FWCore.ParameterSet.Config as cms
 from FWCore.ParameterSet.VarParsing import VarParsing
 
 
-# determine the location of _this_ file
-if "__file__" in globals():
-    this_dir = os.path.dirname(os.path.abspath(__file__))
-else:
-    this_dir = os.path.expandvars("$CMSSW_BASE/src/RecoHGCal/GraphReco/test")
+# # determine the location of _this_ file
+# if "__file__" in globals():
+#     this_dir = os.path.dirname(os.path.abspath(__file__))
+# else:
+#     this_dir = os.path.expandvars("$CMSSW_BASE/src/RecoHGCal/GraphReco/test")
 
-# ensure that the graph exists
-# if not, call the create_dummy_graph.py script in a subprocess since tensorflow complains
-# when its loaded twice (once here in python, once in c++)
-graph_path = os.path.join(this_dir, "graph.pb")
-if not os.path.exists(graph_path):
-    script_path = os.path.join(this_dir, "create_dummy_graph.py")
-    code = subprocess.call(["python", script_path, graph_path])
-    if code != 0:
-        raise Exception("create_dummy_graph.py failed")
+# # ensure that the graph exists
+# # if not, call the create_dummy_graph.py script in a subprocess since tensorflow complains
+# # when its loaded twice (once here in python, once in c++)
+# graph_path = os.path.join(this_dir, "graph.pb")
+# if not os.path.exists(graph_path):
+#     script_path = os.path.join(this_dir, "create_dummy_graph.py")
+#     code = subprocess.call(["python", script_path, graph_path])
+#     if code != 0:
+#         raise Exception("create_dummy_graph.py failed")
 
 # setup minimal options
 options = VarParsing("python")
 options.setDefault("inputFiles", "file:///eos/cms/store/cmst3/group/hgcal/CMG_studies/hgcalsim/sim.RecoTask/closeby_1.0To100.0_idsmix_dR0.3_n5_rnd1_s1/prod5/reco_2327_n100.root")
+options.setDefault('outputFile', 'file:windowntup.root')
 options.parseArguments()
 
 #this one has some tracks
@@ -43,7 +44,7 @@ process = cms.Process("HGR", Phase2C8)
 # standard sequences and modules
 process.load("Configuration.StandardSequences.Services_cff")
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.load("Configuration.Geometry.GeometryExtended2023D41Reco_cff")
+process.load("Configuration.Geometry.GeometryExtended2026D41Reco_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.load('Configuration.StandardSequences.MagneticField_cff')
 process.load('Configuration.StandardSequences.RawToDigi_cff')
@@ -70,8 +71,8 @@ process.options = cms.untracked.PSet(
     wantSummary=cms.untracked.bool(True),
 )
 
-process.TFileService = cms.Service("TFileService", 
-                                   fileName = cms.string("testout.root"))
+process.TFileService = cms.Service("TFileService", fileName = cms.string(
+    options.__getattr__("outputFile", noTags=True)))
 
 # load and configure the windowInference module
 from RecoHGCal.GraphReco.windowNTupler_cfi import WindowNTupler


### PR DESCRIPTION
This PR contains a few basic modifications to technically enable the window ntupler config to run within the hgcalsim production tools (using law).  

Note: the ntupler config does run standalone on the old example reco file specified in the config:

`/eos/cms/store/cmst3/group/hgcal/CMG_studies/hgcalsim/sim.RecoTask/closeby_1.0To100.0_idsmix_dR0.3_n5_rnd1_s1/prod5/reco_2327_n100.root`

as well as on reco files made in the [prodtools branch](https://github.com/CMS-HGCAL/hgcalsim/tree/prodtools) of the CMS-HGCAL/hgcalsim repository. 

However, it does not yet work on a new reco file (with new truth information) produced in the [hgctruth branch](https://github.com/riga/hgcalsim/tree/hgctruth) in the riga/hgcalsim repository, e.g.:

`/eos/cms/store/cmst3/group/hgcal/CMG_studies/gvonsem/hgcalsim/sim.RecoTask/e5579219d4/dev_windowntup_hgctruth_ttbar_trial1/reco_1.root`

The interface needs to be fixed before automatic window ntuple production can be done within the [hgctruth branch](https://github.com/riga/hgcalsim/tree/hgctruth) in the riga/hgcalsim repository. 
